### PR TITLE
Add optional CBLAS matmul path and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+CC ?= gcc
+CFLAGS ?= -O3 -Ofast -march=native -std=c11 -Wall -Wextra
+LDFLAGS ?=
+LIBS ?=
+
+USE_OPENMP ?= 1
+
+SRC := run.c
+TARGET := run
+
+ifeq ($(USE_OPENMP),1)
+CFLAGS += -fopenmp
+endif
+
+ifdef USE_MKL
+CFLAGS += -DLLAMA_USE_MKL
+ifdef MKLROOT
+CFLAGS += -I$(MKLROOT)/include
+LDFLAGS += -L$(MKLROOT)/lib -L$(MKLROOT)/lib/intel64 -L$(MKLROOT)/lib/intel64_lin
+endif
+LIBS += -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lpthread -ldl
+endif
+
+ifdef USE_OPENBLAS
+CFLAGS += -DLLAMA_USE_OPENBLAS
+ifdef OPENBLAS_ROOT
+CFLAGS += -I$(OPENBLAS_ROOT)/include
+LDFLAGS += -L$(OPENBLAS_ROOT)/lib
+endif
+LIBS += -lopenblas
+endif
+
+ifdef USE_ACCELERATE
+CFLAGS += -DLLAMA_USE_ACCELERATE
+LIBS += -framework Accelerate
+endif
+
+LIBS += -lm
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) $(LIBS)
+
+clean:
+	rm -f $(TARGET)
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -65,6 +65,36 @@ gcc -Ofast run.c -o run
 $ gcc -Ofast -fopenmp -march=native run.c win.c -o run
 ```
 
+## performance experiments with batched sgemm
+
+Community experiments have shown that linking `run.c` against a high performance
+BLAS implementation can dramatically increase both prompt processing and token
+generation throughput on CPU-only systems. In particular, a fork that wires
+Intel MKL 2023.1.0 into the attention and prompt-processing paths via
+`cblas_sgemm_batched()` reports the following single-threaded results on a Ryzen
+7 5800X when using GCC 14.1.1 and the prompt from the example below:
+
+| build | prompt tokens/s | generated tokens/s |
+|-------|-----------------|--------------------|
+| baseline `run` | ~1.0 | ~1.0 |
+| MKL fork | 53.70 | 1.33 |
+| llama.cpp (for reference) | 46.14 | 1.29 |
+
+The gains primarily come from:
+
+- A dedicated prompt-processing routine that parallelizes per-token matrix work
+  with batched GEMM calls.
+- Rewriting the attention path to rely on `cblas_sgemm_batched()`.
+- Avoiding redundant computations inside the transformer loop and measuring the
+  full prompt window instead of skipping the first token.
+
+The fork also provides experimental OpenBLAS and standalone back ends. However,
+the OpenBLAS path currently regresses token generation throughput unless
+`forward()` falls back to the original `matmul()` routine, and the standalone
+path lacks an optimized SGEMM kernel. Further work on custom SGEMM
+implementations could enable additional optimizations such as fusing softmax
+preparation into the matrix multiply.
+
 # base model single shot
 This still runs at interactive rates and samples more coherent and diverse stories:
 

--- a/run.c
+++ b/run.c
@@ -7,6 +7,17 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stdint.h>
+#if defined(LLAMA_USE_MKL)
+#include <mkl_cblas.h>
+#define LLAMA_USE_CBLAS 1
+#elif defined(LLAMA_USE_OPENBLAS) || defined(LLAMA_USE_ACCELERATE)
+#include <cblas.h>
+#define LLAMA_USE_CBLAS 1
+#endif
+#ifndef LLAMA_USE_CBLAS
+#define LLAMA_USE_CBLAS 0
+#endif
 #if defined _WIN32
 #include "win.h"
 #else
@@ -232,9 +243,12 @@ void softmax(float *x, int size) {
   }
 }
 
-void matmul(float *xout, float *x, float *w, int n, int d) {
+void matmul(float *xout, const float *x, const float *w, int n, int d) {
   // W (d,n) @ x (n,) -> xout (d,)
   // by far the most amount of time is spent inside this little function
+#if LLAMA_USE_CBLAS
+  cblas_sgemv(CblasRowMajor, CblasNoTrans, d, n, 1.0f, w, n, x, 1, 0.0f, xout, 1);
+#else
   int i;
 #pragma omp parallel for private(i)
   for (i = 0; i < d; i++) {
@@ -244,6 +258,7 @@ void matmul(float *xout, float *x, float *w, int n, int d) {
     }
     xout[i] = val;
   }
+#endif
 }
 
 float *forward(Transformer *transformer, int token, int pos) {


### PR DESCRIPTION
## Summary
- add optional BLAS-backed matmul implementation that uses cblas_sgemv when available
- introduce a configurable Makefile for building with OpenMP, MKL, OpenBLAS, or Accelerate

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68f5a81600808327807d80a1d48a3f82